### PR TITLE
Bump dependencies (esp. argonaut-generic-codecs)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,15 +22,15 @@
   ],
   "dependencies": {
     "purescript-console": "^2.0.0",
-    "purescript-prelude": "^2.1.0",
+    "purescript-prelude": "^2.4.0",
     "purescript-either": "^2.1.0",
     "purescript-argonaut-core": "^2.0.1",
     "purescript-globals": "^2.0.0",
-    "purescript-foldable-traversable": "^2.1.0",
+    "purescript-foldable-traversable": "^2.2.0",
     "purescript-nullable": "^2.0.0",
-    "purescript-dom": "^3.3.1",
+    "purescript-dom": "^3.5.1",
     "purescript-affjax": "^3.0.2",
-    "purescript-argonaut-generic-codecs": "^4.0.0"
+    "purescript-argonaut-generic-codecs": "^5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^2.0.0"


### PR DESCRIPTION
This is breaking because of the changed json encoding in argonaut-generic-codecs.